### PR TITLE
Fix InventoryWear hook

### DIFF
--- a/BC-XToys.user.js
+++ b/BC-XToys.user.js
@@ -953,7 +953,7 @@ const Item_State_Handler = (function () {
         'InventoryWear',
         8,
         (args, next) => {
-            next(args);
+            const ret = next(args);
             if (args[0]?.MemberNumber == Player.MemberNumber) {
                 const itemA = getPlayerAssetByName(args[1]);
                 var name = itemA?.Asset?.Name;
@@ -962,6 +962,7 @@ const Item_State_Handler = (function () {
                     equipToy(name, slot);
                 }
             }
+            return ret;
         }
     );
 


### PR DESCRIPTION
That function has been changed months ago to return the newly worn item. Not grabbing and returning the value can break a few things, so let's do that.

Fixes #2.